### PR TITLE
Update variant to reflect new Arduino board definition

### DIFF
--- a/boards/weact_bluepillplus_gd32f303cc.json
+++ b/boards/weact_bluepillplus_gd32f303cc.json
@@ -18,7 +18,7 @@
       ]
     ],
     "spl_sub_series": "HD",
-    "variant": "GD32F303CC_GENERIC"
+    "variant": "WEACT_BLUEPILLPLUS_GD32F303CC"
   },
   "debug": {
     "jlink_device": "GD32F303CC",


### PR DESCRIPTION
Enable Arduino variant for WeAct Studio Bluepill Plus GD32F303CC