### PR TITLE
fix ccram for gd32f4xx series

### DIFF
--- a/boards/genericGD32F425RE.json
+++ b/boards/genericGD32F425RE.json
@@ -26,7 +26,7 @@
   "name": "GD32F425RE (256k RAM, 512k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f425ret6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F425RG.json
+++ b/boards/genericGD32F425RG.json
@@ -26,7 +26,7 @@
   "name": "GD32F425RG (256k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f425rgt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F425RK.json
+++ b/boards/genericGD32F425RK.json
@@ -26,7 +26,7 @@
   "name": "GD32F425RK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f425rkt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F425VG.json
+++ b/boards/genericGD32F425VG.json
@@ -26,7 +26,7 @@
   "name": "GD32F425VG (256k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f425vgt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F425VK.json
+++ b/boards/genericGD32F425VK.json
@@ -26,7 +26,7 @@
   "name": "GD32F425VK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f425vkt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F425ZG.json
+++ b/boards/genericGD32F425ZG.json
@@ -26,7 +26,7 @@
   "name": "GD32F425ZG (256k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f425zgt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F425ZK.json
+++ b/boards/genericGD32F425ZK.json
@@ -26,7 +26,7 @@
   "name": "GD32F425ZK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f425zkt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427IE.json
+++ b/boards/genericGD32F427IE.json
@@ -26,7 +26,7 @@
   "name": "GD32F427IE (256k RAM, 512k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427ieh6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427IG.json
+++ b/boards/genericGD32F427IG.json
@@ -26,7 +26,7 @@
   "name": "GD32F427IG (256k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427igh6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427IK.json
+++ b/boards/genericGD32F427IK.json
@@ -26,7 +26,7 @@
   "name": "GD32F427IK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427ikh6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427RE.json
+++ b/boards/genericGD32F427RE.json
@@ -26,7 +26,7 @@
   "name": "GD32F427RE (256k RAM, 512k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427ret6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427RG.json
+++ b/boards/genericGD32F427RG.json
@@ -26,7 +26,7 @@
   "name": "GD32F427RG (256k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427rgt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427RK.json
+++ b/boards/genericGD32F427RK.json
@@ -26,7 +26,7 @@
   "name": "GD32F427RK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427rkt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427VE.json
+++ b/boards/genericGD32F427VE.json
@@ -26,7 +26,7 @@
   "name": "GD32F427VE (256k RAM, 512k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427vet6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427VG.json
+++ b/boards/genericGD32F427VG.json
@@ -26,7 +26,7 @@
   "name": "GD32F427VG (256k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427vgt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427VK.json
+++ b/boards/genericGD32F427VK.json
@@ -26,7 +26,7 @@
   "name": "GD32F427VK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427vkt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427ZE.json
+++ b/boards/genericGD32F427ZE.json
@@ -26,7 +26,7 @@
   "name": "GD32F427ZE (256k RAM, 512k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427zet6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427ZG.json
+++ b/boards/genericGD32F427ZG.json
@@ -26,7 +26,7 @@
   "name": "GD32F427ZG (256k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427zgt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F427ZK.json
+++ b/boards/genericGD32F427ZK.json
@@ -26,7 +26,7 @@
   "name": "GD32F427ZK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f427zkt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470IG.json
+++ b/boards/genericGD32F470IG.json
@@ -26,7 +26,7 @@
   "name": "GD32F470IG (512k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 524288,
+    "maximum_ram_size": 458752,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470igh6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470II.json
+++ b/boards/genericGD32F470II.json
@@ -26,7 +26,7 @@
   "name": "GD32F470II (768k RAM, 2048k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 786432,
+    "maximum_ram_size": 720896,
     "maximum_size": 2097152,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470iih6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470IK.json
+++ b/boards/genericGD32F470IK.json
@@ -26,7 +26,7 @@
   "name": "GD32F470IK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470ikh6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470VE.json
+++ b/boards/genericGD32F470VE.json
@@ -26,7 +26,7 @@
   "name": "GD32F470VE (256k RAM, 512k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470vet6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470VG.json
+++ b/boards/genericGD32F470VG.json
@@ -26,7 +26,7 @@
   "name": "GD32F470VG (512k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 524288,
+    "maximum_ram_size": 458752,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470vgt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470VI.json
+++ b/boards/genericGD32F470VI.json
@@ -26,7 +26,7 @@
   "name": "GD32F470VI (768k RAM, 2048k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 786432,
+    "maximum_ram_size": 720896,
     "maximum_size": 2097152,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470vit6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470VK.json
+++ b/boards/genericGD32F470VK.json
@@ -26,7 +26,7 @@
   "name": "GD32F470VK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470vkt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470ZE.json
+++ b/boards/genericGD32F470ZE.json
@@ -26,7 +26,7 @@
   "name": "GD32F470ZE (256k RAM, 512k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470zet6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470ZG.json
+++ b/boards/genericGD32F470ZG.json
@@ -26,7 +26,7 @@
   "name": "GD32F470ZG (512k RAM, 1024k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 524288,
+    "maximum_ram_size": 458752,
     "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470zgt6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470ZI.json
+++ b/boards/genericGD32F470ZI.json
@@ -26,7 +26,7 @@
   "name": "GD32F470ZI (768k RAM, 2048k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 786432,
+    "maximum_ram_size": 720896,
     "maximum_size": 2097152,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470zit6/",
   "vendor": "GigaDevice"

--- a/boards/genericGD32F470ZK.json
+++ b/boards/genericGD32F470ZK.json
@@ -26,7 +26,7 @@
   "name": "GD32F470ZK (256k RAM, 3072k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 262144,
+    "maximum_ram_size": 196608,
     "maximum_size": 3145728,
     "protocol": "stlink",
     "protocols": [
@@ -40,7 +40,8 @@
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,
-    "wait_for_upload_port": false
+    "wait_for_upload_port": false,
+    "closely_coupled_ram_size": 65536
   },
   "url": "https://www.gigadevice.com/microcontroller/gd32f470zkt6/",
   "vendor": "GigaDevice"

--- a/misc/scripts/board_generator.py
+++ b/misc/scripts/board_generator.py
@@ -271,7 +271,7 @@ class GD32MCUInfo:
         # Hence we need to adjust the upoad.maximum_ram_size so that the linker script doesn't
         # set the SP into memory that doesn't exist.
         # the only F4 series that does not have TCMSRAM is GD32F403xx.
-        if self.series == "GD32F405" or self.series == "GD32F407" or self.series == "GD32F450":
+        if self.series.startswith("GD32F4") and not self.name.startswith("GD32F403"):
             # subtract size of TCM SRAM
             # SRAM0 and SRAM1 are contiguous (112 + 16 kB)
             # from GD32F407xx_Datasheet_Rev2.1.pdf page 71


### PR DESCRIPTION
I was trying to run the example blink project on a GD32F470VI and it was always going Hard Fault at SystemInit.
The generated linker file had the whole 768K of ram contiguous on RAM section, and CCRAM section size to 0 so the RAM section was actually overflowing outside the memory space.
I found out that the board generator script was setting the CCRAM section only for GD32F405, GD32F407 and GD32F450, whereas the comment above says that CCRAM should be set for every F4xx except F403, so I fixed the line that is checking for the model.
I also regenerated the boards files.